### PR TITLE
Fix log path creation

### DIFF
--- a/a2dp_test/run_a2dp_tests.py
+++ b/a2dp_test/run_a2dp_tests.py
@@ -1,8 +1,12 @@
 import bluetooth
 import logging
+import os
 
 # Set up logging
-logging.basicConfig(filename='/usr/src/a2dp_test/results/a2dp_test_results.txt', level=logging.INFO)
+results_dir = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(results_dir, exist_ok=True)
+log_file = os.path.join(results_dir, 'a2dp_test_results.txt')
+logging.basicConfig(filename=log_file, level=logging.INFO)
 
 def test_a2dp_streaming():
     logging.info("Starting A2DP streaming test...")

--- a/a2dp_test/run_a2dp_tests_mock.py
+++ b/a2dp_test/run_a2dp_tests_mock.py
@@ -1,8 +1,12 @@
 import logging
 import time
+import os
 
 # Set up logging
-logging.basicConfig(filename='/usr/src/a2dp_test/results/a2dp_test_results.txt', level=logging.INFO)
+results_dir = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(results_dir, exist_ok=True)
+log_file = os.path.join(results_dir, 'a2dp_test_results.txt')
+logging.basicConfig(filename=log_file, level=logging.INFO)
 
 def mock_test_a2dp_streaming():
     logging.info("Starting mock A2DP streaming test...")

--- a/connect_disconnect_test/run_conn_disc_tests.py
+++ b/connect_disconnect_test/run_conn_disc_tests.py
@@ -1,8 +1,12 @@
 import bluetooth
 import logging
+import os
 
 # Set up logging
-logging.basicConfig(filename='/usr/src/connect_disconnect_test/results/conn_disc_test_results.txt', level=logging.INFO)
+results_dir = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(results_dir, exist_ok=True)
+log_file = os.path.join(results_dir, 'conn_disc_test_results.txt')
+logging.basicConfig(filename=log_file, level=logging.INFO)
 
 def test_connect_disconnect():
     logging.info("Starting Connect/Disconnect test...")

--- a/connect_disconnect_test/run_conn_disc_tests_mock.py
+++ b/connect_disconnect_test/run_conn_disc_tests_mock.py
@@ -1,8 +1,12 @@
 import logging
 import time
+import os
 
 # Set up logging
-logging.basicConfig(filename='/usr/src/connect_disconnect_test/results/conn_disc_test_results.txt', level=logging.INFO)
+results_dir = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(results_dir, exist_ok=True)
+log_file = os.path.join(results_dir, 'conn_disc_test_results.txt')
+logging.basicConfig(filename=log_file, level=logging.INFO)
 
 def mock_test_connect_disconnect():
     logging.info("Starting mock Connectivity/Disconnect test...")

--- a/hfp_test/run_hfp_tests.py
+++ b/hfp_test/run_hfp_tests.py
@@ -1,8 +1,12 @@
 import bluetooth
 import logging
+import os
 
 # Set up logging
-logging.basicConfig(filename='/usr/src/hfp_test/results/hfp_test_results.txt', level=logging.INFO)
+results_dir = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(results_dir, exist_ok=True)
+log_file = os.path.join(results_dir, 'hfp_test_results.txt')
+logging.basicConfig(filename=log_file, level=logging.INFO)
 
 def test_hfp_connection():
     # Example of testing HFP connection (pseudo code, adapt to your test case)

--- a/hfp_test/run_hfp_tests_mock.py
+++ b/hfp_test/run_hfp_tests_mock.py
@@ -1,8 +1,12 @@
 import logging
 import time
+import os
 
 # Set up logging
-logging.basicConfig(filename='/usr/src/hfp_test/results/hfp_test_results.txt', level=logging.INFO)
+results_dir = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(results_dir, exist_ok=True)
+log_file = os.path.join(results_dir, 'hfp_test_results.txt')
+logging.basicConfig(filename=log_file, level=logging.INFO)
 
 def mock_test_hfp():
     logging.info("Starting mock HFP test...")


### PR DESCRIPTION
## Summary
- ensure result directory exists for log output

## Testing
- `python3 -m py_compile a2dp_test/run_a2dp_tests.py a2dp_test/run_a2dp_tests_mock.py connect_disconnect_test/run_conn_disc_tests.py connect_disconnect_test/run_conn_disc_tests_mock.py hfp_test/run_hfp_tests.py hfp_test/run_hfp_tests_mock.py`

------
https://chatgpt.com/codex/tasks/task_e_68597c2036308320a6bafc8e5a2cd69a