### PR TITLE
Implement missing scripts and add unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Bluetooth Testing Pipeline
+
+This repository contains a minimal Jenkins based workflow for running Bluetooth
+tests inside Docker containers.  Three different test suites are provided:
+A2DP, HFP and connectivity/disconnect.  Each suite can run either in a mock mode
+(using simulated devices) or against real hardware.
+
+## Quick start
+
+1. Build the test images and start Jenkins along with the test containers:
+
+```bash
+docker-compose up --build
+```
+
+2. Browse to `http://localhost:8080` and configure Jenkins.  The pipeline file
+is located at `jenkins/pipelines/ble_pipline.groovy`.
+
+3. Trigger the pipeline to build the images, execute unit tests via `pytest` and
+finally run the integration tests.  Result logs are written to the `results/`
+directory.
+
+## Directory layout
+
+- `a2dp_test/`, `hfp_test/`, `connect_disconnect_test/` – Individual test
+  suites with Dockerfiles and test scripts.
+- `android_os/` – Placeholder scripts for setting up an Android environment.
+- `jenkins/` – Dockerfile for a Jenkins image and pipeline definition.
+- `docker-compose.yml` – Brings all containers up for local testing.
+
+The project serves as a starting point for further Bluetooth automation.  The
+mock tests can be expanded with real device logic and the Android installation
+script can be replaced with a full emulator setup as needed.

--- a/a2dp_test/test_a2dp.py
+++ b/a2dp_test/test_a2dp.py
@@ -1,0 +1,22 @@
+import sys
+import types
+
+# Provide a minimal bluetooth stub so the module can be imported without the
+# real PyBluez dependency present during CI runs.
+bluetooth_stub = types.ModuleType("bluetooth")
+bluetooth_stub.discover_devices = lambda lookup_names=True: []
+sys.modules.setdefault('bluetooth', bluetooth_stub)
+
+import run_a2dp_tests as real
+from run_a2dp_tests_mock import mock_test_a2dp_streaming
+
+
+def test_mock_runs():
+    """Ensure the mock streaming test executes without error."""
+    mock_test_a2dp_streaming()
+
+
+def test_real_runs(monkeypatch):
+    """Run the real test with a mocked bluetooth discovery."""
+    monkeypatch.setattr(real.bluetooth, "discover_devices", lambda lookup_names=True: [("00:11:22:33:44:55", "Device")])
+    real.test_a2dp_streaming()

--- a/android_os/android_install.sh
+++ b/android_os/android_install.sh
@@ -1,1 +1,16 @@
-#
+#!/bin/bash
+set -e
+
+# This script simulates installation of the Android SDK and creation of an AVD.
+# In a real environment you would download command line tools and create the
+# emulator image. Here we simply create a results log to show it ran.
+
+RESULTS_DIR="$(dirname "$0")/results"
+mkdir -p "$RESULTS_DIR"
+LOGFILE="$RESULTS_DIR/android_install.log"
+
+echo "Starting Android installation..." | tee "$LOGFILE"
+# Placeholder for real installation steps
+# e.g., download command line tools, run sdkmanager, create an AVD, etc.
+
+echo "Android installation complete." | tee -a "$LOGFILE"

--- a/connect_disconnect_test/test_conn_disc.py
+++ b/connect_disconnect_test/test_conn_disc.py
@@ -1,0 +1,20 @@
+import sys
+import types
+
+bluetooth_stub = types.ModuleType("bluetooth")
+bluetooth_stub.discover_devices = lambda lookup_names=True: []
+sys.modules.setdefault('bluetooth', bluetooth_stub)
+
+import run_conn_disc_tests as real
+from run_conn_disc_tests_mock import mock_test_connect_disconnect
+
+
+def test_mock_runs():
+    """Ensure the mock connectivity test executes without error."""
+    mock_test_connect_disconnect()
+
+
+def test_real_runs(monkeypatch):
+    """Run the real test with mocked bluetooth discovery."""
+    monkeypatch.setattr(real.bluetooth, "discover_devices", lambda lookup_names=True: [("11:22:33:44:55:66", "Device")])
+    real.test_connect_disconnect()

--- a/hfp_test/test_hfp.py
+++ b/hfp_test/test_hfp.py
@@ -1,0 +1,20 @@
+import sys
+import types
+
+bluetooth_stub = types.ModuleType("bluetooth")
+bluetooth_stub.discover_devices = lambda lookup_names=True: []
+sys.modules.setdefault('bluetooth', bluetooth_stub)
+
+import run_hfp_tests as real
+from run_hfp_tests_mock import mock_test_hfp
+
+
+def test_mock_runs():
+    """Ensure the mock HFP test executes without error."""
+    mock_test_hfp()
+
+
+def test_real_runs(monkeypatch):
+    """Run the real HFP test with mocked bluetooth discovery."""
+    monkeypatch.setattr(real.bluetooth, "discover_devices", lambda lookup_names=True: [("AA:BB:CC:DD:EE:FF", "Device")])
+    real.test_hfp_connection()

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,11 @@
+FROM jenkins/jenkins:lts
+
+USER root
+RUN apt-get update && apt-get install -y docker.io python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install docker
+USER jenkins
+
+# Copy pipeline definitions into the Jenkins reference job directory so that
+# they are available on first start.
+COPY pipelines /usr/share/jenkins/ref/pipelines

--- a/jenkins/pipelines/ble_pipline.groovy
+++ b/jenkins/pipelines/ble_pipline.groovy
@@ -40,6 +40,32 @@ pipeline {
             }
         }
 
+        stage('Run Unit Tests') {
+            parallel {
+                stage('A2DP Unit') {
+                    steps {
+                        docker.image('a2dp-test-image').inside {
+                            sh 'pytest -q'
+                        }
+                    }
+                }
+                stage('HFP Unit') {
+                    steps {
+                        docker.image('hfp-test-image').inside {
+                            sh 'pytest -q'
+                        }
+                    }
+                }
+                stage('ConnDisc Unit') {
+                    steps {
+                        docker.image('conn-disc-test-image').inside {
+                            sh 'pytest -q'
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Run Bluetooth Tests') {
             parallel {
                 stage('A2DP Test') {


### PR DESCRIPTION
## Summary
- add Android install script
- update Jenkins Dockerfile with dependencies
- integrate a unit test stage in the Jenkins pipeline
- implement simple unit tests for each test suite
- document setup instructions

## Testing
- `pytest -q`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597c1fe9e8832088ebb8c6d1a87726