### PR TITLE
Fix Jenkins pipeline to use python3

### DIFF
--- a/jenkins/pipelines/ble_pipeline.groovy
+++ b/jenkins/pipelines/ble_pipeline.groovy
@@ -47,12 +47,12 @@ pipeline {
                         script {
                             if (env.TEST_MODE == 'mock') {
                                 docker.image('a2dp-test-image').inside {
-                                    sh './a2dp_test/run_a2dp_tests_mock.py'
+                                    sh 'python3 ./a2dp_test/run_a2dp_tests_mock.py'
                                     echo 'Mock A2DP test complete.'
                                 }
                             } else {
                                 docker.image('a2dp-test-image').inside {
-                                    sh './a2dp_test/run_a2dp_tests.py'
+                                    sh 'python3 ./a2dp_test/run_a2dp_tests.py'
                                     echo 'Real A2DP test complete.'
                                 }
                             }
@@ -65,12 +65,12 @@ pipeline {
                         script {
                             if (env.TEST_MODE == 'mock') {
                                 docker.image('hfp-test-image').inside {
-                                    sh './hfp_test/run_hfp_tests_mock.py'
+                                    sh 'python3 ./hfp_test/run_hfp_tests_mock.py'
                                     echo 'Mock HFP test complete.'
                                 }
                             } else {
                                 docker.image('hfp-test-image').inside {
-                                    sh './hfp_test/run_hfp_tests.py'
+                                    sh 'python3 ./hfp_test/run_hfp_tests.py'
                                     echo 'Real HFP test complete.'
                                 }
                             }
@@ -83,12 +83,12 @@ pipeline {
                         script {
                             if (env.TEST_MODE == 'mock') {
                                 docker.image('conn-disc-test-image').inside {
-                                    sh './connect_disconnect_test/run_conn_disc_tests_mock.py'
+                                    sh 'python3 ./connect_disconnect_test/run_conn_disc_tests_mock.py'
                                     echo 'Mock Connectivity/Disconnect test complete.'
                                 }
                             } else {
                                 docker.image('conn-disc-test-image').inside {
-                                    sh './connect_disconnect_test/run_conn_disc_tests.py'
+                                    sh 'python3 ./connect_disconnect_test/run_conn_disc_tests.py'
                                     echo 'Real Connectivity/Disconnect test complete.'
                                 }
                             }


### PR DESCRIPTION
## Summary
- rename pipeline file to `ble_pipeline.groovy`
- run all python test scripts with `python3`

## Testing
- `python3 -m py_compile a2dp_test/run_a2dp_tests_mock.py && echo "OK" && python3 -m py_compile a2dp_test/run_a2dp_tests.py && echo "OK"`
- `python3 -m py_compile hfp_test/run_hfp_tests_mock.py && echo OK && python3 -m py_compile hfp_test/run_hfp_tests.py && echo OK`
- `python3 -m py_compile connect_disconnect_test/run_conn_disc_tests_mock.py && echo OK && python3 -m py_compile connect_disconnect_test/run_conn_disc_tests.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_685e2c899bb88320a7828a846d41fb7c